### PR TITLE
Limit strand observers to one per strand.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "react/promise": "^2"
     },
     "require-dev": {
-        "eloquent/phony": "^0.8",
+        "eloquent/phony": "dev-master",
         "fabpot/php-cs-fixer": "^1",
         "hamcrest/hamcrest-php": "^2.0",
         "peridot-php/leo": "dev-php7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "ebec587cfbfea64a2b7c4d32521ddf5d",
-    "content-hash": "ef25ca92815c7f29c84d7a4ed891ab2b",
+    "hash": "4582b0672dc83fd9c57dd639335f781c",
+    "content-hash": "780d6bff740b3819d07c37f89848a6e2",
     "packages": [
         {
             "name": "icecave/repr",
@@ -150,16 +150,16 @@
     "packages-dev": [
         {
             "name": "eloquent/phony",
-            "version": "0.8.0",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/eloquent/phony.git",
-                "reference": "4aed7850ab624d7b801670cf84478993e2d32e54"
+                "reference": "ff0d9257a20e039ce99364765d8e8043e5b72e94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/eloquent/phony/zipball/4aed7850ab624d7b801670cf84478993e2d32e54",
-                "reference": "4aed7850ab624d7b801670cf84478993e2d32e54",
+                "url": "https://api.github.com/repos/eloquent/phony/zipball/ff0d9257a20e039ce99364765d8e8043e5b72e94",
+                "reference": "ff0d9257a20e039ce99364765d8e8043e5b72e94",
                 "shasum": ""
             },
             "require": {
@@ -169,9 +169,8 @@
                 "athletic/athletic": "^0.1",
                 "counterpart/counterpart": "^1",
                 "danielstjules/pho": "^1",
-                "eloquent/asplode": "^2",
+                "fabpot/php-cs-fixer": "^1",
                 "hamcrest/hamcrest-php": "^1",
-                "icecave/archer": "dev-develop",
                 "icecave/isolator": "^3",
                 "icecave/woodhouse": "dev-develop",
                 "mockery/mockery": "^0.9",
@@ -184,11 +183,6 @@
                 "simpletest/simpletest": "^1"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-develop": "0.8.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Eloquent\\Phony\\": "src"
@@ -224,7 +218,7 @@
                 "stubbing",
                 "test"
             ],
-            "time": "2016-02-12 00:46:30"
+            "time": "2016-03-18 04:53:47"
         },
         {
             "name": "evenement/evenement",
@@ -1487,6 +1481,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
+        "eloquent/phony": 20,
         "peridot-php/leo": 20
     },
     "prefer-stable": false,

--- a/src/Kernel/Exception/StrandException.php
+++ b/src/Kernel/Exception/StrandException.php
@@ -8,7 +8,7 @@ use Recoil\Kernel\Strand;
 use Throwable;
 
 /**
- * A strand, or one of its observers has failed.
+ * A strand or its observer has failed.
  */
 interface StrandException extends Throwable
 {

--- a/src/Kernel/Kernel.php
+++ b/src/Kernel/Kernel.php
@@ -22,10 +22,7 @@ interface Kernel
     /**
      * Run the kernel and wait for all strands to complete.
      *
-     * If {@see Kernel::interrupt()} is called, wait() throws the exception.
-     *
-     * Recoil uses interrupts to indicate failed strands or strand observers,
-     * but interrupts also be used by application code.
+     * @see Kernel::interrupt()
      *
      * @return null
      * @throws Throwable The exception passed to {@see Kernel::interrupt()}.

--- a/src/Kernel/Strand.php
+++ b/src/Kernel/Strand.php
@@ -23,24 +23,6 @@ interface Strand extends AwaitableProvider
     public function kernel();
 
     /**
-     * Add a strand observer.
-     *
-     * @param StrandObserver $observer
-     *
-     * @return null
-     */
-    public function attachObserver(StrandObserver $observer);
-
-    /**
-     * Remove a strand observer.
-     *
-     * @param StrandObserver $observer
-     *
-     * @return null
-     */
-    public function detachObserver(StrandObserver $observer);
-
-    /**
      * Start the strand.
      *
      * @param mixed $coroutine The strand's entry-point.
@@ -80,6 +62,13 @@ interface Strand extends AwaitableProvider
     public function throw(Throwable $exception);
 
     /**
+     * Set the strand observer.
+     *
+     * @return null
+     */
+    public function setObserver(StrandObserver $observer = null);
+
+    /**
      * Set the strand 'terminator'.
      *
      * The terminator is a function invoked when the strand is terminated. It is
@@ -87,8 +76,6 @@ interface Strand extends AwaitableProvider
      *
      * The terminator function is removed without being invoked when the strand
      * is resumed.
-     *
-     * @param callable|null $fn The terminator function.
      *
      * @return null
      */

--- a/src/Kernel/StrandWaitAll.php
+++ b/src/Kernel/StrandWaitAll.php
@@ -29,7 +29,7 @@ final class StrandWaitAll implements Awaitable, StrandObserver
         $this->strand->setTerminator([$this, 'cancel']);
 
         foreach ($this->substrands as $substrand) {
-            $substrand->attachObserver($this);
+            $substrand->setObserver($this);
         }
     }
 
@@ -65,7 +65,7 @@ final class StrandWaitAll implements Awaitable, StrandObserver
 
         foreach ($this->substrands as $s) {
             if ($s !== $strand) {
-                $s->detachObserver($this);
+                $s->setObserver(null);
                 $s->terminate();
             }
         }
@@ -90,7 +90,7 @@ final class StrandWaitAll implements Awaitable, StrandObserver
     public function cancel()
     {
         foreach ($this->substrands as $strand) {
-            $strand->detachObserver($this);
+            $strand->setObserver(null);
             $strand->terminate();
         }
     }

--- a/src/Kernel/StrandWaitAny.php
+++ b/src/Kernel/StrandWaitAny.php
@@ -30,7 +30,7 @@ final class StrandWaitAny implements Awaitable, StrandObserver
         $this->strand->setTerminator([$this, 'cancel']);
 
         foreach ($this->substrands as $substrand) {
-            $substrand->attachObserver($this);
+            $substrand->setObserver($this);
         }
     }
 
@@ -46,7 +46,7 @@ final class StrandWaitAny implements Awaitable, StrandObserver
 
         foreach ($this->substrands as $s) {
             if ($s !== $strand) {
-                $s->detachObserver($this);
+                $s->setObserver(null);
                 $s->terminate();
             }
         }
@@ -93,7 +93,7 @@ final class StrandWaitAny implements Awaitable, StrandObserver
     public function cancel()
     {
         foreach ($this->substrands as $strand) {
-            $strand->detachObserver($this);
+            $strand->setObserver(null);
             $strand->terminate();
         }
     }

--- a/src/Kernel/StrandWaitFirst.php
+++ b/src/Kernel/StrandWaitFirst.php
@@ -29,7 +29,7 @@ final class StrandWaitFirst implements Awaitable, StrandObserver
         $this->strand->setTerminator([$this, 'cancel']);
 
         foreach ($this->substrands as $substrand) {
-            $substrand->attachObserver($this);
+            $substrand->setObserver($this);
         }
     }
 
@@ -45,7 +45,7 @@ final class StrandWaitFirst implements Awaitable, StrandObserver
 
         foreach ($this->substrands as $s) {
             if ($s !== $strand) {
-                $s->detachObserver($this);
+                $s->setObserver(null);
                 $s->terminate();
             }
         }
@@ -66,7 +66,7 @@ final class StrandWaitFirst implements Awaitable, StrandObserver
 
         foreach ($this->substrands as $s) {
             if ($s !== $strand) {
-                $s->detachObserver($this);
+                $s->setObserver(null);
                 $s->terminate();
             }
         }
@@ -91,7 +91,7 @@ final class StrandWaitFirst implements Awaitable, StrandObserver
     public function cancel()
     {
         foreach ($this->substrands as $strand) {
-            $strand->detachObserver($this);
+            $strand->setObserver(null);
             $strand->terminate();
         }
     }

--- a/src/Kernel/StrandWaitOne.php
+++ b/src/Kernel/StrandWaitOne.php
@@ -25,7 +25,7 @@ final class StrandWaitOne implements Awaitable, StrandObserver
         $this->strand = $strand;
         $this->strand->setTerminator([$this, 'cancel']);
 
-        $this->substrand->attachObserver($this);
+        $this->substrand->setObserver($this);
     }
 
     /**
@@ -75,7 +75,7 @@ final class StrandWaitOne implements Awaitable, StrandObserver
     public function cancel()
     {
         if ($this->substrand) {
-            $this->substrand->detachObserver($this);
+            $this->substrand->setObserver(null);
             $this->substrand->terminate();
         }
     }

--- a/src/Kernel/StrandWaitSome.php
+++ b/src/Kernel/StrandWaitSome.php
@@ -42,7 +42,7 @@ final class StrandWaitSome implements Awaitable, StrandObserver
         $this->strand->setTerminator([$this, 'cancel']);
 
         foreach ($this->substrands as $substrand) {
-            $substrand->attachObserver($this);
+            $substrand->setObserver($this);
         }
     }
 
@@ -63,7 +63,7 @@ final class StrandWaitSome implements Awaitable, StrandObserver
 
         if (0 === --$this->count) {
             foreach ($this->substrands as $s) {
-                $s->detachObserver($this);
+                $s->setObserver(null);
                 $s->terminate();
             }
 
@@ -88,7 +88,7 @@ final class StrandWaitSome implements Awaitable, StrandObserver
 
         if ($this->count > count($this->substrands)) {
             foreach ($this->substrands as $s) {
-                $s->detachObserver($this);
+                $s->setObserver(null);
                 $s->terminate();
             }
 
@@ -114,7 +114,7 @@ final class StrandWaitSome implements Awaitable, StrandObserver
     public function cancel()
     {
         foreach ($this->substrands as $strand) {
-            $strand->detachObserver($this);
+            $strand->setObserver(null);
             $strand->terminate();
         }
     }

--- a/src/React/ReactKernel.php
+++ b/src/React/ReactKernel.php
@@ -58,7 +58,7 @@ final class ReactKernel implements Kernel
 
         $kernel = new self($eventLoop);
         $strand = $kernel->execute($coroutine);
-        $strand->attachObserver($observer);
+        $strand->setObserver($observer);
         $kernel->wait();
 
         if ($observer->exception) {
@@ -107,10 +107,7 @@ final class ReactKernel implements Kernel
     /**
      * Run the kernel and wait for all strands to complete.
      *
-     * If {@see Kernel::interrupt()} is called, wait() throws the exception.
-     *
-     * Recoil uses interrupts to indicate failed strands or strand observers,
-     * but interrupts also be used by application code.
+     * @see Kernel::interrupt()
      *
      * @return null
      * @throws Throwable The exception passed to {@see Kernel::interrupt()}.

--- a/src/React/ReactStrand.php
+++ b/src/React/ReactStrand.php
@@ -22,7 +22,7 @@ final class ReactStrand implements Strand, PromisorInterface
     {
         if (!$this->promise) {
             $deferred = new Deferred();
-            $this->attachObserver(new DeferredResolver($deferred));
+            $this->setObserver(new DeferredResolver($deferred));
             $this->promise = $deferred->promise();
         }
 

--- a/test/suite/Kernel/ApiTrait.spec.php
+++ b/test/suite/Kernel/ApiTrait.spec.php
@@ -275,10 +275,10 @@ describe(ApiTrait::class, function () {
             $this->kernel->execute->calledWith('<b>');
 
             Phony::inOrder(
-                $call1 = $this->substrand1->attachObserver->calledWith(
+                $call1 = $this->substrand1->setObserver->calledWith(
                     IsInstanceOf::anInstanceOf(StrandWaitAll::class)
                 ),
-                $call2 = $this->substrand2->attachObserver->calledWith(
+                $call2 = $this->substrand2->setObserver->calledWith(
                     IsInstanceOf::anInstanceOf(StrandWaitAll::class)
                 )
             );
@@ -299,10 +299,10 @@ describe(ApiTrait::class, function () {
             $this->kernel->execute->calledWith('<b>');
 
             Phony::inOrder(
-                $call1 = $this->substrand1->attachObserver->calledWith(
+                $call1 = $this->substrand1->setObserver->calledWith(
                     IsInstanceOf::anInstanceOf(StrandWaitAny::class)
                 ),
-                $call2 = $this->substrand2->attachObserver->calledWith(
+                $call2 = $this->substrand2->setObserver->calledWith(
                     IsInstanceOf::anInstanceOf(StrandWaitAny::class)
                 )
             );
@@ -324,10 +324,10 @@ describe(ApiTrait::class, function () {
             $this->kernel->execute->calledWith('<b>');
 
             Phony::inOrder(
-                $call1 = $this->substrand1->attachObserver->calledWith(
+                $call1 = $this->substrand1->setObserver->calledWith(
                     IsInstanceOf::anInstanceOf(StrandWaitSome::class)
                 ),
-                $call2 = $this->substrand2->attachObserver->calledWith(
+                $call2 = $this->substrand2->setObserver->calledWith(
                     IsInstanceOf::anInstanceOf(StrandWaitSome::class)
                 )
             );
@@ -381,10 +381,10 @@ describe(ApiTrait::class, function () {
             $this->kernel->execute->calledWith('<b>');
 
             Phony::inOrder(
-                $call1 = $this->substrand1->attachObserver->calledWith(
+                $call1 = $this->substrand1->setObserver->calledWith(
                     IsInstanceOf::anInstanceOf(StrandWaitFirst::class)
                 ),
-                $call2 = $this->substrand2->attachObserver->calledWith(
+                $call2 = $this->substrand2->setObserver->calledWith(
                     IsInstanceOf::anInstanceOf(StrandWaitFirst::class)
                 )
             );

--- a/test/suite/Kernel/StrandWaitAll.spec.php
+++ b/test/suite/Kernel/StrandWaitAll.spec.php
@@ -35,8 +35,8 @@ describe(StrandWaitAll::class, function () {
     describe('->await()', function () {
         it('resumes the strand when all substrands complete', function () {
             $this->strand->setTerminator->calledWith([$this->subject, 'cancel']);
-            $this->substrand1->attachObserver->calledWith($this->subject);
-            $this->substrand2->attachObserver->calledWith($this->subject);
+            $this->substrand1->setObserver->calledWith($this->subject);
+            $this->substrand2->setObserver->calledWith($this->subject);
 
             $this->subject->success($this->substrand2->mock(), '<two>');
 
@@ -72,7 +72,7 @@ describe(StrandWaitAll::class, function () {
             $this->subject->terminated($this->substrand1->mock());
 
             Phony::inOrder(
-                $this->substrand2->detachObserver->calledWith($this->subject),
+                $this->substrand2->setObserver->calledWith(null),
                 $this->substrand2->terminate->called(),
                 $this->strand->throw->called()
             );
@@ -85,11 +85,11 @@ describe(StrandWaitAll::class, function () {
 
             $this->subject->cancel();
 
-            $this->substrand1->detachObserver->never()->called();
+            $this->substrand1->setObserver->never()->calledWith(null);
             $this->substrand1->terminate->never()->called();
 
             Phony::inOrder(
-                $this->substrand2->detachObserver->calledWith($this->subject),
+                $this->substrand2->setObserver->calledWith(null),
                 $this->substrand2->terminate->called()
             );
         });

--- a/test/suite/Kernel/StrandWaitAny.spec.php
+++ b/test/suite/Kernel/StrandWaitAny.spec.php
@@ -36,8 +36,8 @@ describe(StrandWaitAny::class, function () {
     describe('->await()', function () {
         it('resumes the strand when any substrand completes', function () {
             $this->strand->setTerminator->calledWith([$this->subject, 'cancel']);
-            $this->substrand1->attachObserver->calledWith($this->subject);
-            $this->substrand2->attachObserver->calledWith($this->subject);
+            $this->substrand1->setObserver->calledWith($this->subject);
+            $this->substrand2->setObserver->calledWith($this->subject);
 
             $this->subject->success($this->substrand1->mock(), '<one>');
 
@@ -82,7 +82,7 @@ describe(StrandWaitAny::class, function () {
             $this->subject->success($this->substrand1->mock(), '<one>');
 
             Phony::inOrder(
-                $this->substrand2->detachObserver->calledWith($this->subject),
+                $this->substrand2->setObserver->calledWith(null),
                 $this->substrand2->terminate->called(),
                 $this->strand->resume->called()
             );
@@ -95,11 +95,11 @@ describe(StrandWaitAny::class, function () {
 
             $this->subject->cancel();
 
-            $this->substrand1->detachObserver->never()->called();
+            $this->substrand1->setObserver->never()->calledWith(null);
             $this->substrand1->terminate->never()->called();
 
             Phony::inOrder(
-                $this->substrand2->detachObserver->calledWith($this->subject),
+                $this->substrand2->setObserver->calledWith(null),
                 $this->substrand2->terminate->called()
             );
         });

--- a/test/suite/Kernel/StrandWaitFirst.spec.php
+++ b/test/suite/Kernel/StrandWaitFirst.spec.php
@@ -35,8 +35,8 @@ describe(StrandWaitFirst::class, function () {
     describe('->await()', function () {
         it('resumes the strand when any substrand completes', function () {
             $this->strand->setTerminator->calledWith([$this->subject, 'cancel']);
-            $this->substrand1->attachObserver->calledWith($this->subject);
-            $this->substrand2->attachObserver->calledWith($this->subject);
+            $this->substrand1->setObserver->calledWith($this->subject);
+            $this->substrand2->setObserver->calledWith($this->subject);
 
             $this->subject->success($this->substrand1->mock(), '<one>');
 
@@ -48,7 +48,7 @@ describe(StrandWaitFirst::class, function () {
             $this->subject->failure($this->substrand1->mock(), $exception->mock());
 
             Phony::inOrder(
-                $this->substrand2->detachObserver->calledWith($this->subject),
+                $this->substrand2->setObserver->calledWith(null),
                 $this->substrand2->terminate->called(),
                 $this->strand->throw->calledWith($exception)
             );
@@ -58,7 +58,7 @@ describe(StrandWaitFirst::class, function () {
             $this->subject->terminated($this->substrand1->mock());
 
             Phony::inOrder(
-                $this->substrand2->detachObserver->calledWith($this->subject),
+                $this->substrand2->setObserver->calledWith(null),
                 $this->substrand2->terminate->called(),
                 $this->strand->throw->calledWith(
                     new TerminatedException($this->substrand1->mock())
@@ -70,7 +70,7 @@ describe(StrandWaitFirst::class, function () {
             $this->subject->success($this->substrand1->mock(), '<one>');
 
             Phony::inOrder(
-                $this->substrand2->detachObserver->calledWith($this->subject),
+                $this->substrand2->setObserver->calledWith(null),
                 $this->substrand2->terminate->called(),
                 $this->strand->resume->called()
             );
@@ -82,12 +82,12 @@ describe(StrandWaitFirst::class, function () {
             $this->subject->cancel();
 
             Phony::inOrder(
-                $this->substrand1->detachObserver->calledWith($this->subject),
+                $this->substrand1->setObserver->calledWith(null),
                 $this->substrand1->terminate->called()
             );
 
             Phony::inOrder(
-                $this->substrand2->detachObserver->calledWith($this->subject),
+                $this->substrand2->setObserver->calledWith(null),
                 $this->substrand2->terminate->called()
             );
         });
@@ -97,10 +97,10 @@ describe(StrandWaitFirst::class, function () {
 
             $this->subject->cancel();
 
-            $this->substrand1->detachObserver->never()->called();
+            $this->substrand1->setObserver->never()->calledWith(null);
             $this->substrand1->terminate->never()->called();
 
-            $this->substrand2->detachObserver->once()->called();
+            $this->substrand2->setObserver->once()->calledWith(null);
             $this->substrand2->terminate->once()->called();
         });
     });

--- a/test/suite/Kernel/StrandWaitOne.spec.php
+++ b/test/suite/Kernel/StrandWaitOne.spec.php
@@ -31,7 +31,7 @@ describe(StrandWaitOne::class, function () {
     describe('->await()', function () {
         it('resumes the strand when the substrand completes', function () {
             $this->strand->setTerminator->calledWith([$this->subject, 'cancel']);
-            $this->substrand->attachObserver->calledWith($this->subject);
+            $this->substrand->setObserver->calledWith($this->subject);
 
             $this->subject->success($this->substrand->mock(), '<one>');
 
@@ -59,7 +59,7 @@ describe(StrandWaitOne::class, function () {
             $this->subject->cancel();
 
             Phony::inOrder(
-                $this->substrand->detachObserver->calledWith($this->subject),
+                $this->substrand->setObserver->calledWith(null),
                 $this->substrand->terminate->called()
             );
         });
@@ -69,7 +69,7 @@ describe(StrandWaitOne::class, function () {
 
             $this->subject->cancel();
 
-            $this->substrand->detachObserver->never()->called();
+            $this->substrand->setObserver->never()->calledWith(null);
             $this->substrand->terminate->never()->called();
         });
     });

--- a/test/suite/Kernel/StrandWaitSome.spec.php
+++ b/test/suite/Kernel/StrandWaitSome.spec.php
@@ -50,9 +50,9 @@ describe(StrandWaitSome::class, function () {
 
     describe('->await()', function () {
         it('resumes the strand when enough substrands complete', function () {
-            $this->substrand1->attachObserver->calledWith($this->subject);
-            $this->substrand2->attachObserver->calledWith($this->subject);
-            $this->substrand3->attachObserver->calledWith($this->subject);
+            $this->substrand1->setObserver->calledWith($this->subject);
+            $this->substrand2->setObserver->calledWith($this->subject);
+            $this->substrand3->setObserver->calledWith($this->subject);
 
             $this->subject->success($this->substrand2->mock(), '<two>');
 
@@ -80,7 +80,7 @@ describe(StrandWaitSome::class, function () {
             $this->subject->failure($this->substrand1->mock(), $exception1->mock());
 
             Phony::inOrder(
-                $this->substrand3->detachObserver->calledWith($this->subject),
+                $this->substrand3->setObserver->calledWith(null),
                 $this->substrand3->terminate->called(),
                 $this->strand->throw->calledWith(
                     new CompositeException(
@@ -98,7 +98,7 @@ describe(StrandWaitSome::class, function () {
             $this->subject->terminated($this->substrand1->mock());
 
             Phony::inOrder(
-                $this->substrand3->detachObserver->calledWith($this->subject),
+                $this->substrand3->setObserver->calledWith(null),
                 $this->substrand3->terminate->called(),
                 $this->strand->throw->calledWith(
                     new CompositeException(
@@ -118,7 +118,7 @@ describe(StrandWaitSome::class, function () {
             $this->subject->success($this->substrand1->mock(), '<one>');
 
             Phony::inOrder(
-                $this->substrand3->detachObserver->calledWith($this->subject),
+                $this->substrand3->setObserver->calledWith(null),
                 $this->substrand3->terminate->called(),
                 $this->strand->resume->called()
             );
@@ -131,16 +131,16 @@ describe(StrandWaitSome::class, function () {
 
             $this->subject->cancel();
 
-            $this->substrand1->detachObserver->never()->called();
+            $this->substrand1->setObserver->never()->calledWith(null);
             $this->substrand1->terminate->never()->called();
 
             Phony::inOrder(
-                $this->substrand2->detachObserver->calledWith($this->subject),
+                $this->substrand2->setObserver->calledWith(null),
                 $this->substrand2->terminate->called()
             );
 
             Phony::inOrder(
-                $this->substrand3->detachObserver->calledWith($this->subject),
+                $this->substrand3->setObserver->calledWith(null),
                 $this->substrand3->terminate->called()
             );
         });


### PR DESCRIPTION
This PR fixxes #93, even though it essentially the opposite of what the original
task called for.  The point is that there is no longer any ambiguity about how
errors should be handled for a given strand.