### PR TITLE
Implement `Kernel::waitForStrand()` and `waitFor()`.

### DIFF
--- a/examples/nested-waits
+++ b/examples/nested-waits
@@ -1,0 +1,47 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * This example shows how to suspend and then resume a strand.
+ *
+ * This pattern is useful when a strand must wait on some operation that is not
+ * coroutine based.
+ */
+
+declare(strict_types = 1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use Recoil\Kernel\Strand;
+use Recoil\React\ReactKernel;
+use Recoil\Recoil;
+
+$kernel = new ReactKernel();
+$kernel->execute(function () {
+    yield 1;
+    echo '-- (5) delayed strand' . PHP_EOL;
+});
+
+$kernel->execute(function () use ($kernel) {
+    echo '-- (2) entry-point called' . PHP_EOL;
+    $strand = yield Recoil::execute(function () use ($kernel) {
+        echo '-- (3) first waitable strand start' . PHP_EOL;
+        $strand = yield Recoil::execute(function () {
+            echo '-- (4) second waitable strand start' . PHP_EOL;
+            yield 2;
+            echo '-- (6) second waitable strand done' . PHP_EOL;
+        });
+
+        $kernel->waitForStrand($strand);
+        echo '-- (7) first waitable strand done' . PHP_EOL;
+    });
+
+    $kernel->waitForStrand($strand);
+    echo '-- (8) entry-point return' . PHP_EOL;
+
+    $kernel->stop();
+});
+
+echo '-- (1) before main wait' . PHP_EOL;
+$kernel->wait();
+echo '-- (9) after main wait' . PHP_EOL;

--- a/src/Kernel/ApiTrait.php
+++ b/src/Kernel/ApiTrait.php
@@ -267,7 +267,7 @@ trait ApiTrait
      *
      * @return null
      */
-    public abstract function cooperate(Strand $strand);
+    abstract public function cooperate(Strand $strand);
 
     /**
      * Suspend the calling strand for a fixed interval.
@@ -277,7 +277,7 @@ trait ApiTrait
      *
      * @return null
      */
-    public abstract function sleep(Strand $strand, float $seconds);
+    abstract public function sleep(Strand $strand, float $seconds);
 
     /**
      * Read data from a stream resource.
@@ -293,7 +293,7 @@ trait ApiTrait
      *
      * @return null
      */
-    public abstract function read(Strand $strand, $stream, int $length = 8192);
+    abstract public function read(Strand $strand, $stream, int $length = 8192);
 
     /**
      * Write data to a stream resource.
@@ -309,7 +309,7 @@ trait ApiTrait
      *
      * @return null
      */
-    public abstract function write(
+    abstract public function write(
         Strand $strand,
         $stream,
         string $buffer,

--- a/src/Kernel/ApiTrait.php
+++ b/src/Kernel/ApiTrait.php
@@ -13,13 +13,6 @@ use UnexpectedValueException;
 
 /**
  * A partial implementation of {@see Api}.
- *
- * Assumes valid implementations of:
- *
- * @method null cooperate(Strand $strand);
- * @method null sleep(Strand $strand, float $seconds);
- * @method null read(Strand $strand, $stream, int $length = 8192);
- * @method null write(Strand $strand, $stream, string $buffer, int $length = PHP_INT_MAX);
  */
 trait ApiTrait
 {
@@ -266,4 +259,60 @@ trait ApiTrait
 
         (new StrandWaitFirst(...$substrands))->await($strand, $this);
     }
+
+    /**
+     * Allow other strands to execute before resuming the calling strand.
+     *
+     * @param Strand $strand The strand executing the API call.
+     *
+     * @return null
+     */
+    public abstract function cooperate(Strand $strand);
+
+    /**
+     * Suspend the calling strand for a fixed interval.
+     *
+     * @param Strand $strand  The strand executing the API call.
+     * @param float  $seconds The interval to wait.
+     *
+     * @return null
+     */
+    public abstract function sleep(Strand $strand, float $seconds);
+
+    /**
+     * Read data from a stream resource.
+     *
+     * The calling strand is resumed with a string containing the data read from
+     * the stream, or with an empty string if the stream has reached EOF.
+     *
+     * It is assumed that the stream is already configured as non-blocking.
+     *
+     * @param Strand   $strand The strand executing the API call.
+     * @param resource $stream A readable stream resource.
+     * @param int      $size   The maximum size of the buffer to return, in bytes.
+     *
+     * @return null
+     */
+    public abstract function read(Strand $strand, $stream, int $length = 8192);
+
+    /**
+     * Write data to a stream resource.
+     *
+     * The calling strand is resumed with the number of bytes written.
+     *
+     * It is assumed that the stream is already configured as non-blocking.
+     *
+     * @param Strand   $strand The strand executing the API call.
+     * @param resource $stream A writable stream resource.
+     * @param string   $buffer The data to write to the stream.
+     * @param int      $length The number of bytes to write from the start of the buffer.
+     *
+     * @return null
+     */
+    public abstract function write(
+        Strand $strand,
+        $stream,
+        string $buffer,
+        int $length = PHP_INT_MAX
+    );
 }

--- a/src/Kernel/Kernel.php
+++ b/src/Kernel/Kernel.php
@@ -22,6 +22,11 @@ interface Kernel
     /**
      * Run the kernel and wait for all strands to exit.
      *
+     * Calls to wait() and waitForStrand() can be nested, which can be used in
+     * synchronous code to block until a particular operation is complete.
+     * However, care must be taken not to introduce deadlocks.
+     *
+     * @see Kernel::waitForStrand()
      * @see Kernel::interrupt()
      *
      * @return null
@@ -30,12 +35,53 @@ interface Kernel
     public function wait();
 
     /**
+     * Run the kernel and wait for a specific strand to exit.
+     *
+     * Calls to wait() and waitForStrand() can be nested, which can be used in
+     * synchronous code to block until a particular operation is complete.
+     * However, care must be taken not to introduce deadlocks.
+     *
+     * @see Kernel::wait()
+     * @see Kernel::interrupt()
+     *
+     * @param Strand $strand The strand to wait for.
+     *
+     * @return mixed               The strand result, on success.
+     * @throws Throwable           The exception passed to {@see Kernel::interrupt()}.
+     * @throws Throwable           The exception thrown by the strand, if failed.
+     * @throws TerminatedException The strand has been terminated.
+     */
+    public function waitForStrand(Strand $strand);
+
+    /**
+     * Run the kernel and wait for a specific coroutine to exit.
+     *
+     * This is a convenience method equivalent to:
+     *
+     *      $strand = $kernel->execute($coroutine);
+     *      $kernel->waitForStrand($strand);
+     *
+     * @see Kernel::execute()
+     * @see Kernel::waitForStrand()
+     *
+     * @param mixed $coroutine The strand's entry-point.
+     *
+     * @return mixed               The return value of the coroutine.
+     * @throws Throwable           The exception produced by the coroutine, if any.
+     * @throws Throwable           The exception used to interrupt the kernel.
+     * @throws TerminatedException The strand has been terminated.
+     */
+    public function waitFor($coroutine);
+
+    /**
      * Interrupt the kernel.
      *
      * Execution of all strands is paused and the given exception is thrown by
      * the current call to {@see Kernel::wait()}. wait() can be called again to
      * resume execution of remaining strands.
      *
+     * @see Kernel::wait()
+     * @see Kernel::waitForStrand()
      * @return null
      */
     public function interrupt(Throwable $exception);

--- a/src/Kernel/KernelTrait.php
+++ b/src/Kernel/KernelTrait.php
@@ -7,11 +7,6 @@ namespace Recoil\Kernel;
 use React\EventLoop\Factory;
 use React\EventLoop\LoopInterface;
 use Recoil\Exception\TerminatedException;
-use Recoil\Kernel\Api;
-use Recoil\Kernel\Kernel;
-use Recoil\Kernel\KernelTrait;
-use Recoil\Kernel\Strand;
-use Recoil\Kernel\StrandObserver;
 use RuntimeException;
 use Throwable;
 
@@ -98,4 +93,30 @@ trait KernelTrait
             $this->execute($coroutine)
         );
     }
+
+    /**
+     * Start a new strand of execution.
+     *
+     * The implementation must delay execution of the strand until the next
+     * 'tick' of the kernel to allow the user to inspect the strand object
+     * before execution begins.
+     *
+     * @param mixed $coroutine The strand's entry-point.
+     */
+    public abstract function execute($coroutine) : Strand;
+
+    /**
+     * Run the kernel and wait for all strands to exit.
+     *
+     * Calls to wait() and waitForStrand() can be nested, which can be used in
+     * synchronous code to block until a particular operation is complete.
+     * However, care must be taken not to introduce deadlocks.
+     *
+     * @see Kernel::waitForStrand()
+     * @see Kernel::interrupt()
+     *
+     * @return null
+     * @throws Throwable The exception passed to {@see Kernel::interrupt()}.
+     */
+    public abstract function wait();
 }

--- a/src/Kernel/KernelTrait.php
+++ b/src/Kernel/KernelTrait.php
@@ -39,18 +39,21 @@ trait KernelTrait
 
             public function success(Strand $strand, $value)
             {
+                $strand->kernel()->stop();
                 $this->exited = true;
                 $this->value = $value;
             }
 
             public function failure(Strand $strand, Throwable $exception)
             {
+                $strand->kernel()->stop();
                 $this->exited = true;
                 $this->exception = $exception;
             }
 
             public function terminated(Strand $strand)
             {
+                $strand->kernel()->stop();
                 $this->exited = true;
                 $this->exception = new TerminatedException($strand);
             }
@@ -66,7 +69,7 @@ trait KernelTrait
             return $observer->value;
         }
 
-        throw new RuntimeException('The entry-point coroutine never returned.');
+        throw new RuntimeException('The strand never exited.');
     }
 
     /**

--- a/src/Kernel/KernelTrait.php
+++ b/src/Kernel/KernelTrait.php
@@ -1,0 +1,101 @@
+<?php
+
+declare (strict_types = 1); // @codeCoverageIgnore
+
+namespace Recoil\Kernel;
+
+use React\EventLoop\Factory;
+use React\EventLoop\LoopInterface;
+use Recoil\Exception\TerminatedException;
+use Recoil\Kernel\Api;
+use Recoil\Kernel\Kernel;
+use Recoil\Kernel\KernelTrait;
+use Recoil\Kernel\Strand;
+use Recoil\Kernel\StrandObserver;
+use RuntimeException;
+use Throwable;
+
+trait KernelTrait
+{
+    /**
+     * Run the kernel and wait for a specific strand to exit.
+     *
+     * Calls to wait() and waitForStrand() can be nested, which can be used in
+     * synchronous code to block until a particular operation is complete.
+     * However, care must be taken not to introduce deadlocks.
+     *
+     * @see Kernel::wait()
+     * @see Kernel::interrupt()
+     *
+     * @param Strand $strand The strand to wait for.
+     *
+     * @return mixed The return value of the strand's entry-point coroutine.
+     * @throws Throwable The exception produced by the strand, if any.
+     * @throws Throwable The exception used to interrupt the kernel.
+     * @throws TerminatedException The strand has been terminated.
+     */
+    public function waitForStrand(Strand $strand)
+    {
+        $observer = new class implements StrandObserver
+        {
+            public $value;
+            public $exception;
+            public $exited = false;
+
+            public function success(Strand $strand, $value)
+            {
+                $this->exited = true;
+                $this->value = $value;
+            }
+
+            public function failure(Strand $strand, Throwable $exception)
+            {
+                $this->exited = true;
+                $this->exception = $exception;
+            }
+
+            public function terminated(Strand $strand)
+            {
+                $this->exited = true;
+                $this->exception = new TerminatedException($strand);
+            }
+        };
+
+        $strand->setObserver($observer);
+
+        $this->wait();
+
+        if ($observer->exception) {
+            throw $observer->exception;
+        } elseif ($observer->exited) {
+            return $observer->value;
+        }
+
+        throw new RuntimeException('The entry-point coroutine never returned.');
+    }
+
+    /**
+     * Run the kernel and wait for a specific coroutine to exit.
+     *
+     * This is a convenience method equivalent to:
+     *
+     *      $strand = $kernel->execute($coroutine);
+     *      $kernel->waitForStrand($strand);
+     *
+     * @see Kernel::execute()
+     * @see Kernel::waitForStrand()
+     *
+     * @param mixed              $coroutine The strand's entry-point.
+     *
+     * @return mixed The return value of the coroutine.
+     * @throws Throwable The exception produced by the coroutine, if any.
+     * @throws Throwable The exception used to interrupt the kernel.
+     * @throws TerminatedException The strand has been terminated.
+     */
+    public function waitFor($coroutine)
+    {
+        $this->waitForStrand(
+            $this->execute($coroutine)
+        );
+    }
+}

--- a/src/Kernel/KernelTrait.php
+++ b/src/Kernel/KernelTrait.php
@@ -89,7 +89,7 @@ trait KernelTrait
      */
     public function waitFor($coroutine)
     {
-        $this->waitForStrand(
+        return $this->waitForStrand(
             $this->execute($coroutine)
         );
     }

--- a/src/React/ReactKernel.php
+++ b/src/React/ReactKernel.php
@@ -9,9 +9,8 @@ use React\EventLoop\LoopInterface;
 use Recoil\Exception\TerminatedException;
 use Recoil\Kernel\Api;
 use Recoil\Kernel\Kernel;
+use Recoil\Kernel\KernelTrait;
 use Recoil\Kernel\Strand;
-use Recoil\Kernel\StrandObserver;
-use RuntimeException;
 use Throwable;
 
 /**
@@ -28,49 +27,17 @@ final class ReactKernel implements Kernel
      * @param mixed              $coroutine The strand's entry-point.
      * @param LoopInterface|null $eventLoop The event loop to use (null = default).
      *
-     * @return mixed The return value of the coroutine.
-     * @throws Throwable The exception produced by the coroutine, if any.
-     * @throws Throwable The exception used to interrupt the kernel.
+     * @return mixed               The return value of the coroutine.
+     * @throws Throwable           The exception produced by the coroutine, if any.
+     * @throws Throwable           The exception used to interrupt the kernel.
+     * @throws TerminatedException The strand has been terminated.
      */
     public static function start($coroutine, LoopInterface $eventLoop = null)
     {
-        $observer = new class implements StrandObserver
-        {
-            public $value;
-            public $exception;
-            public $exited = false;
-
-            public function success(Strand $strand, $value)
-            {
-                $this->exited = true;
-                $this->value = $value;
-            }
-
-            public function failure(Strand $strand, Throwable $exception)
-            {
-                $this->exited = true;
-                $this->exception = $exception;
-            }
-
-            public function terminated(Strand $strand)
-            {
-                $this->exited = true;
-                $this->exception = new TerminatedException($strand);
-            }
-        };
-
         $kernel = new self($eventLoop);
         $strand = $kernel->execute($coroutine);
-        $strand->setObserver($observer);
-        $kernel->wait();
 
-        if ($observer->exception) {
-            throw $observer->exception;
-        } elseif ($observer->exited) {
-            return $observer->value;
-        }
-
-        throw new RuntimeException('The entry-point coroutine never returned.');
+        return $kernel->waitForStrand($strand);
     }
 
     /**
@@ -110,8 +77,14 @@ final class ReactKernel implements Kernel
     /**
      * Run the kernel and wait for all strands to exit.
      *
+     * Calls to wait() and waitForStrand() can be nested, which can be used in
+     * synchronous code to block until a particular operation is complete.
+     * However, care must be taken not to introduce deadlocks.
+     *
+     * @see Kernel::waitFor()
      * @see Kernel::interrupt()
      *
+     * @return null
      * @throws Throwable The exception passed to {@see Kernel::interrupt()}.
      */
     public function wait()
@@ -146,6 +119,8 @@ final class ReactKernel implements Kernel
     {
         $this->eventLoop->stop();
     }
+
+    use KernelTrait;
 
     /**
      * @var LoopInterface The event loop.

--- a/test/src/functional-tests.php
+++ b/test/src/functional-tests.php
@@ -28,34 +28,32 @@ function rit(string $description, callable $test)
     });
 }
 
-function importFunctionalTests(string $description, callable $factory)
+function importFunctionalTests(callable $factory)
 {
-    context("Functional Tests ($description)", function () use ($factory) {
-        beforeEach(function () use ($factory) {
-            $this->kernel = $factory();
-            expect($this->kernel)->to->be->an->instanceof(Kernel::class);
-        });
-
-        $walk = null;
-        $walk = function ($path) use (&$walk) {
-            foreach (scandir($path) as $entry) {
-                $fq = $path . '/' . $entry;
-                $matches = null;
-
-                if ($entry[0] === '.') {
-                    continue;
-                } elseif (is_dir($fq)) {
-                    context($entry, function () use ($fq, $walk) {
-                        $walk($fq);
-                    });
-                } elseif (preg_match('/^functional.(.+).spec.php$/', $entry, $matches)) {
-                    context($matches[1], function () use ($fq) {
-                        require $fq;
-                    });
-                }
-            }
-        };
-
-        $walk(__DIR__ . '/../suite-functional');
+    beforeEach(function () use ($factory) {
+        $this->kernel = $factory();
+        expect($this->kernel)->to->be->an->instanceof(Kernel::class);
     });
+
+    $walk = null;
+    $walk = function ($path) use (&$walk) {
+        foreach (scandir($path) as $entry) {
+            $fq = $path . '/' . $entry;
+            $matches = null;
+
+            if ($entry[0] === '.') {
+                continue;
+            } elseif (is_dir($fq)) {
+                context($entry, function () use ($fq, $walk) {
+                    $walk($fq);
+                });
+            } elseif (preg_match('/^functional.(.+).spec.php$/', $entry, $matches)) {
+                context($matches[1], function () use ($fq) {
+                    require $fq;
+                });
+            }
+        }
+    };
+
+    $walk(__DIR__ . '/../suite-functional');
 }

--- a/test/suite/Kernel/KernelTrait.spec.php
+++ b/test/suite/Kernel/KernelTrait.spec.php
@@ -1,0 +1,32 @@
+<?php
+
+declare (strict_types = 1); // @codeCoverageIgnore
+
+namespace Recoil\Kernel;
+
+use Exception;
+
+describe(KernelTrait::class, function () {
+
+    xdescribe('->waitForStrand()', function () {
+        it('runs the event loop', function () {
+            $this->subject->wait();
+            $this->eventLoop->run->called();
+        });
+
+        it('can be invoked again after an interrupt', function () {
+            $this->eventLoop->run->does(function () {
+                $this->subject->interrupt(new Exception());
+            });
+
+            expect(function () {
+                $this->subject->wait();
+            })->to->throw(Exception::class);
+
+            expect(function () {
+                $this->subject->wait();
+            })->to->be->ok;
+        });
+    });
+
+});

--- a/test/suite/Kernel/KernelTrait.spec.php
+++ b/test/suite/Kernel/KernelTrait.spec.php
@@ -4,28 +4,109 @@ declare (strict_types = 1); // @codeCoverageIgnore
 
 namespace Recoil\Kernel;
 
+use Eloquent\Phony\Phony;
 use Exception;
+use Recoil\Exception\TerminatedException;
+use RuntimeException;
 
 describe(KernelTrait::class, function () {
 
-    xdescribe('->waitForStrand()', function () {
-        it('runs the event loop', function () {
-            $this->subject->wait();
-            $this->eventLoop->run->called();
+    beforeEach(function () {
+        $this->strand = Phony::mock(Strand::class);
+
+        $this->subject = Phony::partialMock(
+            [Kernel::class, KernelTrait::class]
+        );
+
+        $this->strand->kernel->returns($this->subject);
+    });
+
+    describe('->waitForStrand()', function () {
+        it('sets the strand observer before waiting', function () {
+            $this->strand->setObserver->does(
+                function ($observer) {
+                    $observer->success($this->strand->mock(), null);
+                }
+            );
+
+            $this->subject->mock()->waitForStrand($this->strand->mock());
+
+            Phony::inOrder(
+                $this->strand->setObserver->called(),
+                $this->subject->wait->called()
+            );
         });
 
-        it('can be invoked again after an interrupt', function () {
-            $this->eventLoop->run->does(function () {
-                $this->subject->interrupt(new Exception());
-            });
+        it('returns the coroutine result', function () {
+            $this->strand->setObserver->does(
+                function ($observer) {
+                    $observer->success($this->strand->mock(), '<ok>');
+                }
+            );
+
+            $result = $this->subject->mock()->waitForStrand($this->strand->mock());
+            $this->subject->stop->called();
+            expect($result)->to->equal('<ok>');
+        });
+
+        it('propagates uncaught exceptions', function () {
+            $this->strand->setObserver->does(
+                function ($observer) {
+                    $observer->failure(
+                        $this->strand->mock(),
+                        new Exception('<exception>')
+                    );
+                }
+            );
 
             expect(function () {
-                $this->subject->wait();
-            })->to->throw(Exception::class);
+                $this->subject->mock()->waitForStrand($this->strand->mock());
+            })->to->throw(
+                Exception::class,
+                '<exception>'
+            );
+
+            $this->subject->stop->called();
+        });
+
+        it('throws an exception if the strand is terminated', function () {
+            $this->strand->setObserver->does(
+                function ($observer) {
+                    $observer->terminated($this->strand->mock());
+                }
+            );
 
             expect(function () {
-                $this->subject->wait();
-            })->to->be->ok;
+                $this->subject->mock()->waitForStrand($this->strand->mock());
+            })->to->throw(TerminatedException::class);
+
+            $this->subject->stop->called();
+        });
+
+        it('detects abandoned strands', function () {
+            expect(function () {
+                $this->subject->mock()->waitForStrand($this->strand->mock());
+            })->to->throw(
+                RuntimeException::class,
+                'The strand never exited.'
+            );
+
+            $this->subject->stop->never()->called();
+        });
+    });
+
+    describe('->waitFor()', function () {
+        it('creates a new strand and waits for it', function () {
+            $this->subject->execute->returns($this->strand);
+
+            $this->subject->waitForStrand->returns('<ok>');
+            $result = $this->subject->mock()->waitFor('<coroutine>');
+
+            Phony::inOrder(
+                $this->subject->execute->calledWith('<coroutine>'),
+                $this->subject->waitForStrand->calledWith($this->strand)
+            );
+            expect($result)->to->equal('<ok>');
         });
     });
 

--- a/test/suite/React/ReactKernel.functional.spec.php
+++ b/test/suite/React/ReactKernel.functional.spec.php
@@ -4,9 +4,12 @@ declare (strict_types = 1); // @codeCoverageIgnore
 
 namespace Recoil\React;
 
-\Recoil\importFunctionalTests(
-    'ReactPHP',
-    function () {
-        return new ReactKernel();
-    }
-);
+describe('ReactPHP Integration', function () {
+
+    \Recoil\importFunctionalTests(
+        function () {
+            return new ReactKernel();
+        }
+    );
+
+});

--- a/test/suite/React/ReactKernel.spec.php
+++ b/test/suite/React/ReactKernel.spec.php
@@ -25,7 +25,7 @@ describe(ReactKernel::class, function () {
         );
     });
 
-    describe('->start()', function () {
+    describe('::start()', function () {
         it('returns the coroutine result', function () {
             $result = ReactKernel::start(function () {
                 return yield Recoil::eventLoop();
@@ -53,7 +53,7 @@ describe(ReactKernel::class, function () {
                 });
             })->to->throw(
                 RuntimeException::class,
-                'The entry-point coroutine never returned.'
+                'The strand never exited.'
             );
         });
 


### PR DESCRIPTION
Fixes #96.