### PR TITLE
Add `Api::resume()` and `throw()`.

### DIFF
--- a/src/Kernel/Api.php
+++ b/src/Kernel/Api.php
@@ -6,6 +6,7 @@ namespace Recoil\Kernel;
 
 use Recoil\Exception\CompositeException;
 use Recoil\Exception\TimeoutException;
+use Throwable;
 
 interface Api
 {
@@ -132,6 +133,42 @@ interface Api
         Strand $strand,
         callable $suspendFn = null,
         callable $terminateFn = null
+    );
+
+    /**
+     * Resume execution of a suspended strand on the next "tick".
+     *
+     * This causes the suspended strand's blocking suspend() call to return
+     * $value.
+     *
+     * @param Strand $strand    The strand executing the API call.
+     * @param Strand $suspended The suspended strand.
+     * @param mixed  $value     The value to pass to the resumed strand.
+     *
+     * @return Generator|null
+     */
+    public function resume(
+        Strand $strand,
+        Strand $suspended,
+        $value = null
+    );
+
+    /**
+     * Resume execution of a suspended strand with an error on the next "tick".
+     *
+     * This causes the suspended strand's blocking suspend() call to throw
+     * $exception.
+     *
+     * @param Strand    $strand    The strand executing the API call.
+     * @param Strand    $suspended The suspended strand.
+     * @param Throwable $exception The exception to pass to the resumed strand.
+     *
+     * @return Generator|null
+     */
+    public function throw(
+        Strand $strand,
+        Strand $suspended,
+        Throwable $exception
     );
 
     /**

--- a/src/Kernel/Api.php
+++ b/src/Kernel/Api.php
@@ -136,10 +136,13 @@ interface Api
     );
 
     /**
-     * Resume execution of a suspended strand on the next "tick".
+     * Resume execution of a suspended strand.
      *
      * This causes the suspended strand's blocking suspend() call to return
      * $value.
+     *
+     * The implementation must delay execution of the resumed strand until the
+     * next 'tick' of the kernel.
      *
      * @param Strand $strand    The strand executing the API call.
      * @param Strand $suspended The suspended strand.
@@ -154,10 +157,13 @@ interface Api
     );
 
     /**
-     * Resume execution of a suspended strand with an error on the next "tick".
+     * Resume execution of a suspended strand with an error.
      *
      * This causes the suspended strand's blocking suspend() call to throw
      * $exception.
+     *
+     * The implementation must delay execution of the resumed strand until the
+     * next 'tick' of the kernel.
      *
      * @param Strand    $strand    The strand executing the API call.
      * @param Strand    $suspended The suspended strand.

--- a/src/React/ReactApi.php
+++ b/src/React/ReactApi.php
@@ -97,6 +97,9 @@ final class ReactApi implements Api
      * This causes the suspended strand's blocking suspend() call to return
      * $value.
      *
+     * The implementation must delay execution of the resumed strand until the
+     * next 'tick' of the kernel.
+     *
      * @param Strand $strand    The strand executing the API call.
      * @param Strand $suspended The suspended strand.
      * @param mixed  $value     The value to pass to the resumed strand.
@@ -122,6 +125,9 @@ final class ReactApi implements Api
      *
      * This causes the suspended strand's blocking suspend() call to throw
      * $exception.
+     *
+     * The implementation must delay execution of the resumed strand until the
+     * next 'tick' of the kernel.
      *
      * @param Strand    $strand    The strand executing the API call.
      * @param Strand    $suspended The suspended strand.


### PR DESCRIPTION
These operations resume a suspended strand on the next 'tick'.

Note that this is a repurposing of the `throw` name, which was removed in 0.5.0 (previously `throw_`)..